### PR TITLE
Add support for Android armeabi-v7a architecture

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,3 +45,15 @@ jobs:
       library_type: both
       artifact_name: android-aarch64
       build_name: Android aarch64
+
+  build-armv7a:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-common.yml
+    with:
+      platform: android
+      arch: armv7a
+      runner_os: ubuntu-latest
+      library_type: both
+      artifact_name: android-armv7a
+      build_name: Android armeabi-v7a

--- a/scripts/android/configure-android.sh
+++ b/scripts/android/configure-android.sh
@@ -43,6 +43,9 @@ echo "::endgroup::"
 ASM_FLAGS=""
 if [ "$ARCH" == "x86_64" ]; then
   ASM_FLAGS="-Dlibass:asm=disabled -DFFmpeg:x86asm=disabled"
+elif [ "$ARCH" == "armv7a" ]; then
+  # armv7a supports ASM, no flags needed
+  ASM_FLAGS=""
 fi
 
 # Configure meson build

--- a/scripts/android/copy-android-libraries.sh
+++ b/scripts/android/copy-android-libraries.sh
@@ -89,6 +89,9 @@ if echo "${CPP_COMPILER}" | grep -q "aarch64"; then
 elif echo "${CPP_COMPILER}" | grep -q "x86_64"; then
     ARCH_DIR="x86_64-linux-android"
     echo "Detected architecture from compiler path: x86_64"
+elif echo "${CPP_COMPILER}" | grep -q "armv7a"; then
+    ARCH_DIR="arm-linux-androideabi"
+    echo "Detected architecture from compiler path: armv7a (ARM)"
 else
     echo "::warning::Could not detect architecture from compiler path"
     # Fallback based on input argument
@@ -98,6 +101,9 @@ else
     elif [ "${ARCH}" == "x86_64" ]; then
         ARCH_DIR="x86_64-linux-android"
         echo "Using fallback architecture from argument: x86_64"
+    elif [ "${ARCH}" == "armv7a" ]; then
+        ARCH_DIR="arm-linux-androideabi"
+        echo "Using fallback architecture from argument: armv7a"
     fi
 fi
 echo "NDK architecture directory: ${ARCH_DIR}"

--- a/scripts/android/create-android-cross.sh
+++ b/scripts/android/create-android-cross.sh
@@ -14,14 +14,20 @@ if [ "$ARCH" == "aarch64" ]; then
   ANDROID_ABI="aarch64-linux-android21"
   CPU_FAMILY="aarch64"
   CPU="aarch64"
+  CMAKE_SYSTEM_PROCESSOR="aarch64"
+  CMAKE_ANDROID_ARCH_ABI="arm64-v8a"
 elif [ "$ARCH" == "x86_64" ]; then
   ANDROID_ABI="x86_64-linux-android21"
   CPU_FAMILY="x86_64"
   CPU="x86_64"
+  CMAKE_SYSTEM_PROCESSOR="x86_64"
+  CMAKE_ANDROID_ARCH_ABI="x86_64"
 elif [ "$ARCH" == "armv7a" ]; then
   ANDROID_ABI="armv7a-linux-androideabi21"
   CPU_FAMILY="arm"
   CPU="armv7a"
+  CMAKE_SYSTEM_PROCESSOR="armv7-a"
+  CMAKE_ANDROID_ARCH_ABI="armeabi-v7a"
 else
   echo "Unsupported architecture: $ARCH"
   echo "Usage: $0 [aarch64|x86_64|armv7a]"
@@ -52,6 +58,8 @@ cpp_link_args = ['${PAGE_SIZE_FLAGS}']
 
 [cmake]
 CMAKE_POSITION_INDEPENDENT_CODE='ON'
+CMAKE_SYSTEM_PROCESSOR='${CMAKE_SYSTEM_PROCESSOR}'
+CMAKE_ANDROID_ARCH_ABI='${CMAKE_ANDROID_ARCH_ABI}'
 EOF
 
 echo "Created android-${ARCH}-cross.txt"

--- a/scripts/android/create-android-cross.sh
+++ b/scripts/android/create-android-cross.sh
@@ -18,9 +18,13 @@ elif [ "$ARCH" == "x86_64" ]; then
   ANDROID_ABI="x86_64-linux-android21"
   CPU_FAMILY="x86_64"
   CPU="x86_64"
+elif [ "$ARCH" == "armv7a" ]; then
+  ANDROID_ABI="armv7a-linux-androideabi21"
+  CPU_FAMILY="arm"
+  CPU="armv7a"
 else
   echo "Unsupported architecture: $ARCH"
-  echo "Usage: $0 [aarch64|x86_64]"
+  echo "Usage: $0 [aarch64|x86_64|armv7a]"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add armeabi-v7a (32-bit ARM) build support to the Android CI pipeline
- Update all Android build scripts to handle the armv7a architecture
- Enable building libmpv for older 32-bit ARM Android devices

## Changes

### Workflow Changes
- Added `build-armv7a` job to `.github/workflows/android.yml` that builds for the armv7a architecture

### Script Updates
- **create-android-cross.sh**: Added armv7a configuration with correct Android ABI (`armv7a-linux-androideabi21`) and CPU family settings
- **configure-android.sh**: Added armv7a handling for ASM flags (armv7a supports ASM, no special flags needed)
- **copy-android-libraries.sh**: Added detection for `arm-linux-androideabi` architecture directory when copying `libc++_shared.so`

## Testing

This PR enables the CI pipeline to build armeabi-v7a libraries. The workflow will automatically build and create artifacts for this architecture.

## Related

This expands Android platform coverage to include 32-bit ARM devices, complementing the existing aarch64 and x86_64 builds.